### PR TITLE
[BUG] fix text overflow issue

### DIFF
--- a/js/pptxjs.js
+++ b/js/pptxjs.js
@@ -8696,8 +8696,8 @@
                         prg_width_node = total_text_len + bu_width;
                     }
                 }
-                var prg_width = ((prg_width_node !== undefined) ? ("width:" + (prg_width_node )) + "px;" : "width:inherit;");
-                text += "<div style='height: 100%;direction: initial;overflow-wrap:break-word;word-wrap: break-word;" + prg_width + margin + "' >";
+                var prg_width = !!prg_width_node ? `width:${prg_width_node}px;` : "width:inherit;";
+                text += `<div style='height:100%; direction:initial; overflow-wrap:break-word; word-wrap:break-word; ${prg_width}; ${margin}'>`;
                 text += prgrph_text;
                 text += "</div>";
                 text += "</div>";


### PR DESCRIPTION
## Problem
I notice an instance where text fails to wrap around properly. A paragraph will render as a long single-lined sentence that exceed the slide width

## Root Cause
When determining text width, it was only comparing with `undefined` but `parsedInt` used above can result in `NaN`

## Test
[file](https://github.com/user-attachments/files/20531146/pptx.multiple.features.pptx) used for testing created in original (office 365)
<img width="600" alt="Screenshot 2025-05-28 at 3 49 11 PM" src="https://github.com/user-attachments/assets/05269c0b-5821-49dd-b241-c0203c40b6f2" />
before
<img width="600" alt="Screenshot 2025-05-28 at 4 08 15 PM" src="https://github.com/user-attachments/assets/be8fb27f-7add-4671-b58c-cfc38efda8af" />
after
<img width="600" alt="Screenshot 2025-05-28 at 4 08 22 PM" src="https://github.com/user-attachments/assets/1a724f97-b094-420d-a6dc-1801ed0f6855" />