### PR TITLE
[BUG] fix table merge cell across row and column

### DIFF
--- a/js/pptxjs.js
+++ b/js/pptxjs.js
@@ -9976,26 +9976,22 @@
                                         }
                                     }
 
-                                    var cellParmAry = getTableCellParams(tcNodes[j], getColsGrid, i , j , thisTblStyle, a_sorce, warpObj)
-                                    var text = cellParmAry[0];
-                                    var colStyl = cellParmAry[1];
-                                    var cssName = cellParmAry[2];
-                                    var rowSpan = cellParmAry[3];
-                                    var colSpan = cellParmAry[4];
+                                    const cellParmAry = getTableCellParams(tcNodes[j], getColsGrid, i , j , thisTblStyle, a_sorce, warpObj)
+                                    const text = cellParmAry[0];
+                                    const colStyl = cellParmAry[1];
+                                    const cssName = cellParmAry[2];
+                                    const rowSpan = parseInt(cellParmAry[3]) || 1;
+                                    const colSpan = parseInt(cellParmAry[4]) || 1;
+                                    const hMerge = cellParmAry[5];
 
-
-
-                                    if (rowSpan !== undefined) {
+                                    if (rowSpan) {
                                         totalrowSpan++;
-                                        rowSpanAry[j] = parseInt(rowSpan) - 1;
-                                        tableHtml += "<td class='" + cssName + "' data-row='" + i + "," + j + "' rowspan ='" +
-                                            parseInt(rowSpan) + "' style='" + colStyl + "'>" + text + "</td>";
-                                    } else if (colSpan !== undefined) {
-                                        tableHtml += "<td class='" + cssName + "' data-row='" + i + "," + j + "' colspan = '" +
-                                            parseInt(colSpan) + "' style='" + colStyl + "'>" + text + "</td>";
-                                        totalColSpan = parseInt(colSpan) - 1;
-                                    } else {
-                                        tableHtml += "<td class='" + cssName + "' data-row='" + i + "," + j + "' style = '" + colStyl + "'>" + text + "</td>";
+                                        for (let i = 0; i < colSpan; i++) {
+                                            rowSpanAry[j+i] = rowSpan - 1;
+                                        }
+                                    }
+                                    if (!hMerge) {
+                                        tableHtml += `<td class="${cssName}" data-row="${i},${j}" rowspan="${rowSpan}" colspan="${colSpan}" style="${colStyl}">${text}</td>`
                                     }
 
                                 } else {
@@ -10222,7 +10218,7 @@
             colStyl += ((colFontClrPr !== "") ? "color: #" + colFontClrPr + ";" : "");
             colStyl += ((colFontWeight != "") ? " font-weight:" + colFontWeight + ";" : "");
 
-            return [text, colStyl, cssName, rowSpan, colSpan];
+            return [text, colStyl, cssName, rowSpan, colSpan, hMerge];
         }
 
         function genChart(node, warpObj) {


### PR DESCRIPTION
## Problem
I notice an instance where table with merge cell is not render correctly when a cell span across both row and column

## Root Cause
The current code fail to account the possibility that a cell can span across both row and column and the way `if ... else if ..` is set up will only account for one.

## Test
[file](https://github.com/user-attachments/files/20531146/pptx.multiple.features.pptx) used for testing created in original (office 365)
<img width="600" alt="Screenshot 2025-05-28 at 3 28 56 PM" src="https://github.com/user-attachments/assets/17c10ea0-8231-4fcb-99b5-ac9f742185fb" />
before
<img width="600" alt="Screenshot 2025-05-28 at 4 07 55 PM" src="https://github.com/user-attachments/assets/957bd252-d956-4d14-85fb-640fbb8048bb" />
after
<img width="600" alt="Screenshot 2025-05-28 at 4 08 03 PM" src="https://github.com/user-attachments/assets/b6a049d3-f04d-476d-a9c2-5680fab36373" />
